### PR TITLE
Updates upgrade commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ any linux based system.  There is a full guide to installing Helpy in the wiki: 
 Requirements are:
 
 - Ruby 2.4+
-- Rails 4.2.x
+- Rails 5.0.7
 - Postgres
 - A server like Unicorn, Puma or Passenger
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -16,8 +16,8 @@ Whether you run the open source community edition or the cloud edition, start by
 `bundle install`
 
 3. Run any new migrations, and update the assets:
-`RAILS_ENV=production bundle exec rake db:migrate`
-`RAILS_ENV=production bundle exec rake assets:precompile`
+`RAILS_ENV=production bundle exec rails db:migrate`
+`RAILS_ENV=production bundle exec rails assets:precompile`
 
 4. Restart the webserver.
 
@@ -32,6 +32,6 @@ If you are running the cloud edition, perform the following additional steps:
 `rails g helpy_cloud:install`
 
 3. Update assets:
-`RAILS_ENV=production bundle exec rake assets:precompile`
+`RAILS_ENV=production bundle exec rails assets:precompile`
 
 4. Restart webserver


### PR DESCRIPTION
With move from Rails 4 to 5, the rake commands are replaced by rails commands.